### PR TITLE
feat: upgrade to here api 3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@types/chai": "^4.0.1",
     "@types/enzyme": "^3.10.8",
-    "@types/heremaps": "3.0.7",
+    "@types/heremaps": "^3.1.5",
     "@types/highlight.js": "^9.1.9",
     "@types/jquery": "^3.2.6",
     "@types/loadjs": "^4.0.0",

--- a/src/utils/get-marker-icon.ts
+++ b/src/utils/get-marker-icon.ts
@@ -11,9 +11,9 @@ export const Icons = new Map<string, H.map.Icon>();
  * @param bitmap {string} - The location of the bitmap to be used as an icon
  * Note: this can cause a memleak if used with dynamically generated bitmaps.
  */
-export default function getMarkerIcon(bitmap: string): H.map.Icon {
+export default function getMarkerIcon(bitmap: string, anchor?: H.math.IPoint): H.map.Icon {
   if (!Icons.has(bitmap)) {
-    const icon = new H.map.Icon(bitmap);
+    const icon = new H.map.Icon(bitmap, anchor ? { anchor, crossOrigin: false } : undefined);
     Icons.set(bitmap, icon);
   }
 

--- a/src/utils/get-platform.ts
+++ b/src/utils/get-platform.ts
@@ -1,4 +1,4 @@
-let platform: any;
+let platform: H.service.Platform;
 
 // return the current platform if there is one,
 // otherwise open up a new platform

--- a/src/utils/get-script-map.ts
+++ b/src/utils/get-script-map.ts
@@ -7,7 +7,7 @@ export interface ScriptMap {
 export function getScriptMap(secure?: boolean): ScriptMap {
   // store the versions of the HERE API
   const apiVersion = "v3";
-  const codeVersion = "3.0";
+  const codeVersion = "3.1";
 
   // get the relevant protocol for the HERE Maps API
   let protocol = "";

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,10 +43,10 @@
     "@types/cheerio" "*"
     "@types/react" "*"
 
-"@types/heremaps@3.0.7":
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/@types/heremaps/-/heremaps-3.0.7.tgz#d67c239e529db7cf65f3ce5bb3018c6ba1bdf0d0"
-  integrity sha512-AgyKCL4W//rtwJc+RLx3IjVdJ/puuJheh1EC07LgUWwM2XfV6HPM542ZR2gvSBJgaf7RGd+OAqvSd2MPAIyuvQ==
+"@types/heremaps@^3.1.5":
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/@types/heremaps/-/heremaps-3.1.5.tgz#fa0eca4a923d00b0092517e7c1745649fb8b50e3"
+  integrity sha512-I9hLvguxz4+waIoJajJFravPNOk1tiRf4LylBLk7hnQXjX/qVJn5ZTBLskAGjB047VyTKPE7Eb/yO43Ssjok/g==
 
 "@types/highlight.js@^9.1.9":
   version "9.12.4"


### PR DESCRIPTION
Can be tested alongside https://github.com/impargo/impargo-apps/pull/7966 (note: the impargo-apps PR is still not 100% finalized and still needs some cleanups).

Notable differences:
1. HERE API upgraded to 3.1 but loaded in the same way. An alternative loading method (for example using the [npm package](https://developer.here.com/documentation/maps/3.1.34.1/dev_guide/topics/react-practices.html) however it needed additional work. It can be done as a separate issue.
2. @types/heremaps updated, however it's still not 100% in sync with the 3.1 implementation.
3. Vector tiles are available but still not used by default. They can be enabled via the `useVectorTiles` prop. They look slightly different to the raster tiles. The most notable difference is that major roads are not visible in the map until a further zoom level, which might be annoying for users (not sure).
4. Changed truck tile to a different endpoint, it should however provide the same results.
5. Changed the traffic tile to use the builtin traffic provider.
6. Deprecated `children` option for markers due to the noticeable performance degradation when panning across the map. Using the `bitmap` prop is now the preferred method.
7. Added `anchor` prop to markers to help position the markers better.
8. Added event listeners to the marker and route props to make handling hover and drag events easier.