### PR TITLE
feat: disable fractional zoom

### DIFF
--- a/src/HEREMap.tsx
+++ b/src/HEREMap.tsx
@@ -245,6 +245,9 @@ export const HEREMap = forwardRef<HEREMapRef, HEREMapProps>(({
       const behavior = interactive ? new H.mapevents.Behavior(new H.mapevents.MapEvents(newMap)) : undefined;
 
       if (behavior) {
+        // @ts-ignore
+        behavior.disable(H.mapevents.Behavior.Feature.FRACTIONAL_ZOOM);
+
         // create the default UI for the map
         ui = H.ui.UI.createDefault(newMap, defaultLayersRef.current, language);
         if (disableMapSettings) {


### PR DESCRIPTION
According to the migration guide https://developer.here.com/documentation/maps/3.1.34.2/dev_guide/topics/migration.html that should help with the blurry raster maps.