### PR TITLE
fix(map): traffic layer should work with legacy engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@impargo/react-here-maps",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "React.js HERE Maps component",
   "main": "dist/main.js",
   "scripts": {

--- a/src/HEREMap.tsx
+++ b/src/HEREMap.tsx
@@ -88,10 +88,11 @@ export const HEREMap = forwardRef<HEREMapRef, HEREMapProps>(({
 
   const defaultLayersRef = useRef<H.service.DefaultLayers>(null);
   const trafficOverlayLayerRef = useRef<H.map.layer.TileLayer>(null);
+  const trafficBaseLayerRef = useRef<H.map.layer.TileLayer>(null);
   const truckOverlayLayerRef = useRef<H.map.layer.TileLayer>(null);
   const truckCongestionLayerRef = useRef<H.map.layer.TileLayer>(null);
 
-  const usedMapTiles = (useVectorTiles || trafficLayer)
+  const usedMapTiles = useVectorTiles
     ? defaultLayersRef.current?.vector.normal
     : defaultLayersRef.current?.raster.normal;
 
@@ -196,6 +197,25 @@ export const HEREMap = forwardRef<HEREMapRef, HEREMapProps>(({
       },
     };
   };
+  const getTrafficBaseProvider = (): H.map.provider.ImageTileProvider.Options => {
+    return {
+      getURL(col, row, level) {
+        return ["https://",
+          "1.traffic.maps.ls.hereapi.com/maptile/2.1/traffictile/newest/normal.day/",
+          level,
+          "/",
+          col,
+          "/",
+          row,
+          "/256/png8",
+          "?apiKey=",
+          apiKey,
+          "&=ppi",
+          hidpi ? "320" : "72",
+        ].join("");
+      },
+    };
+  };
   useEffect(() => {
     loadScripts(secure, !useVectorTiles).then(() => {
       if (unmountedRef.current) {
@@ -214,10 +234,12 @@ export const HEREMap = forwardRef<HEREMapRef, HEREMapProps>(({
       const truckOverlayProvider = new H.map.provider.ImageTileProvider(getTruckLayerProvider(false));
       const truckOverlayCongestionProvider = new H.map.provider.ImageTileProvider(getTruckLayerProvider(true));
       const trafficOverlayProvider = new H.map.provider.ImageTileProvider(getTrafficOverlayProvider());
+      const trafficBaseProvider = new H.map.provider.ImageTileProvider(getTrafficBaseProvider());
 
       truckOverlayLayerRef.current = new H.map.layer.TileLayer(truckOverlayProvider);
       truckCongestionLayerRef.current = new H.map.layer.TileLayer(truckOverlayCongestionProvider);
       trafficOverlayLayerRef.current = new H.map.layer.TileLayer(trafficOverlayProvider);
+      trafficBaseLayerRef.current = new H.map.layer.TileLayer(trafficBaseProvider);
 
       const hereMapEl = document.querySelector(`#map-container-${uniqueIdRef.current}`);
       const baseLayer = useVectorTiles
@@ -282,11 +304,13 @@ export const HEREMap = forwardRef<HEREMapRef, HEREMapProps>(({
       const emptyBaseLayer = usedMapTiles.map;
       const baseLayer = useSatellite
         ? satelliteBaseLayer
-        : emptyBaseLayer;
+        : (trafficLayer && !useVectorTiles)
+         ? trafficBaseLayerRef.current
+         : emptyBaseLayer;
 
       map.setBaseLayer(baseLayer);
     }
-  }, [map, useSatellite, usedMapTiles]);
+  }, [map, useSatellite, usedMapTiles, trafficLayer]);
 
   useEffect(() => {
     if (map) {
@@ -318,10 +342,12 @@ export const HEREMap = forwardRef<HEREMapRef, HEREMapProps>(({
   useEffect(() => {
     if (map) {
       if (trafficLayer) {
-        // Adding the vector traffic layer is not strictly necessary,
-        // however it's helpful because it changes the color for roads
-        // and highways to white which makes the traffic data more visible.
-        map.addLayer(defaultLayersRef.current.vector.normal.traffic);
+        if (useVectorTiles) {
+          // Adding the vector traffic layer is not strictly necessary,
+          // however it's helpful because it changes the color for roads
+          // and highways to white which makes the traffic data more visible.
+          map.addLayer(defaultLayersRef.current.vector.normal.traffic);
+        }
         // Ideally, we wouldn't need to add an additional layer here and
         // the vector traffic layer added above would be enough, however
         // the vector traffic layer is only visible on a high zoom level,


### PR DESCRIPTION
## What the PR Includes
- [x] Fixed the base layer when vector tiles are disabled (when using legacy engine) and traffic layer is enabled.
