### PR TITLE
fix(map): use correct satellite layer to show map labels

### DIFF
--- a/src/HEREMap.tsx
+++ b/src/HEREMap.tsx
@@ -300,7 +300,7 @@ export const HEREMap = forwardRef<HEREMapRef, HEREMapProps>(({
 
   useEffect(() => {
     if (map) {
-      const satelliteBaseLayer = defaultLayersRef.current.raster.satellite.base;
+      const satelliteBaseLayer = defaultLayersRef.current.raster.satellite.map;
       const emptyBaseLayer = usedMapTiles.map;
       const baseLayer = useSatellite
         ? satelliteBaseLayer


### PR DESCRIPTION
## What the PR Includes
- [x] Used correct satellite layer (map instead of base) to show map labels (cities, roads, etc)

## Checklist
- [ ] Tests are added.
- [ ] Manual testing instructions are added.
- [ ] Configs are added/adapted if applicable.
- [x] Issue is properly linked if applicable.
