### PR TITLE
refactor: separate raster and vector logic and fix edge cases

### DIFF
--- a/src/useRasterLayers.ts
+++ b/src/useRasterLayers.ts
@@ -1,0 +1,161 @@
+import { useEffect, useMemo } from "react";
+import { Language } from "./utils/languages";
+
+export interface UseRasterLayersProps {
+  map?: H.Map;
+  truckRestrictions?: boolean;
+  trafficLayer?: boolean;
+  incidentsLayer?: boolean;
+  useSatellite?: boolean;
+  congestion?: boolean;
+  defaultLayers?: H.service.DefaultLayers;
+  apiKey: string;
+  lg?: Language;
+  hidpi?: boolean;
+  useVectorTiles: boolean;
+}
+
+const getLayers = (apiKey: string, lg?: Language, hidpi?: boolean) => {
+  const getTruckLayerProvider = (enableCongestion: boolean): H.map.provider.ImageTileProvider.Options => {
+    return {
+      max: 20,
+      min: 8,
+      getURL(col, row, level) {
+        return ["https://",
+          "1.base.maps.ls.hereapi.com/maptile/2.1/truckonlytile/newest/normal.day/",
+          level,
+          "/",
+          col,
+          "/",
+          row,
+          "/256/png8",
+          "?style=fleet",
+          "&apiKey=",
+          apiKey,
+          enableCongestion ? "&congestion" : "",
+          "&lg=",
+          lg,
+          "&ppi=",
+          hidpi ? "320" : "72",
+        ].join("");
+      },
+    };
+  };
+  const getTrafficOverlayProvider = (): H.map.provider.ImageTileProvider.Options => {
+    return {
+      getURL(col, row, level) {
+        return ["https://",
+          "1.traffic.maps.ls.hereapi.com/maptile/2.1/flowtile/newest/normal.day/",
+          level,
+          "/",
+          col,
+          "/",
+          row,
+          "/256/png8",
+          "?apiKey=",
+          apiKey,
+          "&ppi=",
+          hidpi ? "320" : "72",
+        ].join("");
+      },
+    };
+  };
+  const getTrafficBaseProvider = (): H.map.provider.ImageTileProvider.Options => {
+    return {
+      getURL(col, row, level) {
+        return ["https://",
+          "1.traffic.maps.ls.hereapi.com/maptile/2.1/traffictile/newest/normal.day/",
+          level,
+          "/",
+          col,
+          "/",
+          row,
+          "/256/png8",
+          "?apiKey=",
+          apiKey,
+          "&ppi=",
+          hidpi ? "320" : "72",
+        ].join("");
+      },
+    };
+  };
+
+  const truckOverlayProvider = new H.map.provider.ImageTileProvider(getTruckLayerProvider(false));
+  const truckOverlayCongestionProvider = new H.map.provider.ImageTileProvider(getTruckLayerProvider(true));
+  const trafficOverlayProvider = new H.map.provider.ImageTileProvider(getTrafficOverlayProvider());
+  const trafficBaseProvider = new H.map.provider.ImageTileProvider(getTrafficBaseProvider());
+
+  return {
+    trafficBaseLayer: new H.map.layer.TileLayer(trafficBaseProvider),
+    trafficOverlayLayer: new H.map.layer.TileLayer(trafficOverlayProvider),
+    truckCongestionLayer: new H.map.layer.TileLayer(truckOverlayCongestionProvider),
+    truckOverlayLayer: new H.map.layer.TileLayer(truckOverlayProvider),
+  };
+};
+
+export const useRasterLayers = ({
+  map,
+  useSatellite,
+  trafficLayer,
+  congestion,
+  truckRestrictions,
+  incidentsLayer,
+  defaultLayers,
+  apiKey,
+  lg,
+  hidpi,
+  useVectorTiles,
+}: UseRasterLayersProps) => {
+  const layers = useMemo(() => map && getLayers(apiKey, lg, hidpi), [apiKey, lg, hidpi, map]);
+
+  useEffect(() => {
+    if (map && layers && !useVectorTiles && defaultLayers) {
+      const satelliteBaseLayer = defaultLayers?.raster.satellite.map;
+      const emptyBaseLayer = defaultLayers?.raster.normal.map;
+      const baseLayer = useSatellite
+        ? satelliteBaseLayer
+        : trafficLayer
+          ? layers.trafficBaseLayer
+          : emptyBaseLayer;
+
+      map.setBaseLayer(baseLayer);
+    }
+  }, [map, useSatellite, defaultLayers, trafficLayer, useVectorTiles, layers]);
+
+  useEffect(() => {
+    if (map && layers && !useVectorTiles) {
+      if (truckRestrictions) {
+        if (congestion) {
+          map.removeLayer(layers.truckOverlayLayer);
+          map.addLayer(layers.truckCongestionLayer);
+        } else {
+          map.removeLayer(layers.truckCongestionLayer);
+          map.addLayer(layers.truckOverlayLayer);
+        }
+      } else {
+        map.removeLayer(layers.truckCongestionLayer);
+        map.removeLayer(layers.truckOverlayLayer);
+      }
+    }
+  }, [truckRestrictions, congestion, map, useVectorTiles, layers]);
+
+  useEffect(() => {
+    if (map && !useVectorTiles && defaultLayers) {
+      if (incidentsLayer) {
+        map.addLayer(defaultLayers.raster.normal.trafficincidents!);
+      } else {
+        map.removeLayer(defaultLayers.raster.normal.trafficincidents!);
+      }
+    }
+  }, [incidentsLayer, map, defaultLayers, useVectorTiles]);
+
+  useEffect(() => {
+    if (map && layers && !useVectorTiles) {
+      if (trafficLayer) {
+        map.addLayer(layers.trafficOverlayLayer);
+      } else {
+        map.removeLayer(layers.trafficOverlayLayer);
+      }
+    }
+  }, [trafficLayer, map, useVectorTiles, layers]);
+};

--- a/src/useVectorLayers.ts
+++ b/src/useVectorLayers.ts
@@ -1,0 +1,57 @@
+import { useEffect } from "react";
+
+export interface UseVectorLayersProps {
+  map?: H.Map;
+  truckRestrictions?: boolean;
+  trafficLayer?: boolean;
+  incidentsLayer?: boolean;
+  useSatellite?: boolean;
+  congestion?: boolean;
+  defaultLayers?: H.service.DefaultLayers;
+  useVectorTiles: boolean;
+}
+
+export const useVectorLayers = ({
+  map,
+  useSatellite,
+  trafficLayer,
+  congestion,
+  truckRestrictions,
+  incidentsLayer,
+  defaultLayers,
+  useVectorTiles,
+}: UseVectorLayersProps) => {
+  useEffect(() => {
+    if (map && defaultLayers && useVectorTiles) {
+      if (truckRestrictions) {
+        // @ts-ignore
+        map.setBaseLayer(defaultLayers.vector.normal.truck);
+      } else {
+        map.setBaseLayer(useSatellite
+          ? defaultLayers.raster.satellite.map
+          : defaultLayers.vector.normal.map);
+      }
+    }
+  }, [truckRestrictions, congestion, map, useVectorTiles, useSatellite]);
+
+  useEffect(() => {
+    if (map && defaultLayers && useVectorTiles) {
+      if (incidentsLayer) {
+        map.addLayer(defaultLayers.vector.normal.trafficincidents);
+      } else {
+        map.removeLayer(defaultLayers.vector.normal.trafficincidents);
+      }
+    }
+  }, [incidentsLayer, map, defaultLayers, useVectorTiles]);
+
+  useEffect(() => {
+    if (map && defaultLayers && useVectorTiles) {
+      if (trafficLayer) {
+        map.addLayer(defaultLayers.vector.normal.traffic);
+      } else {
+        map.removeLayer(defaultLayers.vector.normal.traffic);
+      }
+    }
+  }, [trafficLayer, map, defaultLayers, useVectorTiles]);
+
+};


### PR DESCRIPTION
## What the PR Includes
- [x] Separate logic of raster tiles and vector tiles for better management.
- [x] Use correct truck tiles when using vector tiles.
- [x] Fix edge case of using satellite base tiles with vector truck tiles (not allowed).

Read more about vector map tiles here: https://developer.here.com/documentation/maps/3.1.41.1/dev_guide/topics/vector.html

## Checklist
- [ ] Tests are added.
- [ ] Manual testing instructions are added.
- [ ] Configs are added/adapted if applicable.
- [x] Issue is properly linked if applicable.
