### PR TITLE
chore: add publish command

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,50 @@
+name: PUBLISH
+on:    
+  repository_dispatch:
+    types: [publish-command]
+jobs:
+  release-pull-request:
+    name: ReleaseAction
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        ref: ${{ github.event.client_payload.pull_request.head.ref }}
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 14
+        registry-url: https://npm.pkg.github.com/
+    - name: Install
+      run: yarn install --frozen-lockfile
+    - name: Get Latest @impargo/react-here-maps version
+      id: package-lts-version
+      run: | 
+        PACKAGE_LTS_VERSION=$(npm view @impargo/react-here-maps dist-tags.latest)
+        major_version=$(echo $PACKAGE_LTS_VERSION | cut -d'-' -f1)
+        echo "::set-output name=LTS_VERSION::$major_version"
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: publish-gpr
+      run:  |
+        git config --global user.email "action@github.com"
+        git config --global user.name  "GitHub Action"
+        yarn publish --no-git-tag-version --new-version ${{ steps.package-lts-version.outputs.LTS_VERSION }}-pre-${{ github.run_number }}
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+    - name: Show Published version
+      run: |
+        echo "PACKAGE VERSION: ${{ steps.package-lts-version.outputs.LTS_VERSION }}-pre-${{ github.run_number }}"
+    - name: Create comment
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+        issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
+        reactions: rocket,hooray
+        body: |
+          RUN URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PACKAGE VERSION: ${{ steps.package-lts-version.outputs.LTS_VERSION }}-pre-${{ github.run_number }}

--- a/.github/workflows/slash_commands.yml
+++ b/.github/workflows/slash_commands.yml
@@ -1,0 +1,15 @@
+name: Slash-commands
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  slash-command:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: peter-evans/slash-command-dispatch@v2
+      with:
+        token: ${{secrets.ADMIN_ACCESS_TOKEN}}
+        issue-type: pull-request
+        commands: |
+          publish

--- a/README.md
+++ b/README.md
@@ -181,3 +181,7 @@ If the Marker component has children, we generate that markup and use it as a Do
 
 [coveralls-image]: https://img.shields.io/coveralls/Josh-ES/react-here-maps.svg?style=flat-square
 [coveralls-url]: https://coveralls.io/github/Josh-ES/react-here-maps
+
+### Publishing a Pre-release Package Version
+
+To generate a pre-release package from the changes in a pull request, add a `/publish` comment in the PR. This will publish a new package version and add a comment in the PR with the details of the published version.


### PR DESCRIPTION
This PR adds pre-release functionality to the repo.

**Usage**
In any PR, simply add a comment `/publish` to publish a pre-release version of the package to make testing easier.