### PR TITLE
chore(publish-workflow): show the published version in the logs

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -37,16 +37,9 @@ jobs:
       env:
         NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
 
-    - name: Show Published version
+    - name: Display Version
       run: |
-        echo "PACKAGE VERSION: ${{ steps.package-lts-version.outputs.LTS_VERSION }}-pre-${{ github.run_number }}"
-    - name: Create comment
-      uses: peter-evans/create-or-update-comment@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-        issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
-        reactions: rocket,hooray
-        body: |
-          RUN URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          PACKAGE VERSION: ${{ steps.package-lts-version.outputs.LTS_VERSION }}-pre-${{ github.run_number }}
+        echo ""
+        echo -e "\033[1;34m==========================================\033[0m"
+        echo -e "\033[1;32m       🚀 Version: ${{ steps.package-lts-version.outputs.LTS_VERSION }}-pre-${{ github.run_number }}       \033[0m"
+        echo -e "\033[1;34m==========================================\033[0m"

--- a/README.md
+++ b/README.md
@@ -184,4 +184,4 @@ If the Marker component has children, we generate that markup and use it as a Do
 
 ### Publishing a Pre-release Package Version
 
-To generate a pre-release package from the changes in a pull request, add a `/publish` comment in the PR. This will publish a new package version and add a comment in the PR with the details of the published version.
+To generate a pre-release package from the changes in a pull request, add a `/publish` comment in the PR. This will publish a new package version and then you can check the Display Version step in the Action run to find the details of the published version.


### PR DESCRIPTION
There are some restrictions on repository forks that prevents creating comments on the PR, because:
1- The `GITHUB_TOKEN` has read-only access.
2- Events from forks cannot access secrets(Including PAT).


Instead of that,  the Publish action will show them in logs like this one:
![image](https://github.com/user-attachments/assets/9b6e572a-c0e2-423c-b67d-01d5a79c7454)
